### PR TITLE
#05 Search Filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "generate:types": "payload generate:types"
+    "generate:types": "payload generate:types",
+    "db:fresh": "payload migrate:fresh"
   },
   "dependencies": {
     "@payloadcms/db-mongodb": "^3.38.0",

--- a/src/app/(app)/(home)/layout.tsx
+++ b/src/app/(app)/(home)/layout.tsx
@@ -1,14 +1,45 @@
+import { getPayload } from "payload";
+import configPromise from "@payload-config";
+
+import { Category } from "@/payload-types";
+
 import { Footer } from "./footer";
 import { Navbar } from "./navbar";
+import SearchFilters from "./search-filters";
 
 interface Props {
   children: React.ReactNode;
 }
 
-const Layout = ({ children }: Props) => {
+const Layout = async ({ children }: Props) => {
+  const payload = await getPayload({
+    config: configPromise,
+  });
+
+  const data = await payload.find({
+    collection: "categories",
+    depth: 1, // Populate subcategories, subcategories.[0] will be a type of "Category"
+    pagination: false, // 카테고리는 페이지네이션이 필요없습니다
+    where: {
+      parent: {
+        exists: false,
+      },
+    },
+  });
+
+  const formattedData = data.docs.map((doc) => ({
+    ...doc,
+    subcategories: (doc.subcategories?.docs ?? []).map((doc) => ({
+      // Because of 'depth: 1' we are confident "doc" will be a type of "Category"
+      ...(doc as Category),
+      subcategories: undefined,
+    })),
+  }));
+
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
+      <SearchFilters data={formattedData} />
       <div className="flex-1 bg-[#F4F4F0]">{children}</div>
       <Footer />
     </div>

--- a/src/app/(app)/(home)/page.tsx
+++ b/src/app/(app)/(home)/page.tsx
@@ -8,6 +8,12 @@ export default async function Home() {
 
   const data = await payload.find({
     collection: "categories",
+    depth: 1, // Populate subcategories
+    where: {
+      parent: {
+        exists: false,
+      },
+    },
   });
 
   return (

--- a/src/app/(app)/(home)/page.tsx
+++ b/src/app/(app)/(home)/page.tsx
@@ -1,24 +1,7 @@
-import configPromise from "@payload-config";
-import { getPayload } from "payload";
-
-export default async function Home() {
-  const payload = await getPayload({
-    config: configPromise,
-  });
-
-  const data = await payload.find({
-    collection: "categories",
-    depth: 1, // Populate subcategories
-    where: {
-      parent: {
-        exists: false,
-      },
-    },
-  });
-
+export default function Home() {
   return (
     <div>
-      <div>{JSON.stringify(data, null, 2)}</div>
+      <div>Home Page</div>
     </div>
   );
 }

--- a/src/app/(app)/(home)/search-filters/categories.tsx
+++ b/src/app/(app)/(home)/search-filters/categories.tsx
@@ -1,0 +1,24 @@
+import { Category } from "@/payload-types";
+import { CategoryDropdown } from "./category-dropdown";
+
+interface Props {
+  data: any;
+}
+
+export const Categories = ({ data }: Props) => {
+  return (
+    <div className="relative w-full">
+      <div className="flex flex-nowrap items-center">
+        {data?.map((category: Category) => (
+          <div key={category.id}>
+            <CategoryDropdown
+              category={category}
+              isActive={false}
+              isNavigationHovered={false}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/app/(app)/(home)/search-filters/category-dropdown.tsx
+++ b/src/app/(app)/(home)/search-filters/category-dropdown.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+import { cn } from "@/lib/utils";
+import { Category } from "@/payload-types";
+
+import { Button } from "@/components/ui/button";
+import { useDropdownPosition } from "./use-dropdown-position";
+import { SubCategoryMenu } from "./subcategory-menu";
+
+interface Props {
+  category: Category;
+  isActive?: boolean;
+  isNavigationHovered?: boolean;
+}
+
+export const CategoryDropdown = ({
+  category,
+  isActive,
+  isNavigationHovered,
+}: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const { getDropdownPosition } = useDropdownPosition(dropdownRef);
+
+  const onMouseEnter = () => {
+    if (category.subcategories) {
+      setIsOpen(true);
+    }
+  };
+
+  const onMouseLeave = () => setIsOpen(false);
+
+  const dropdownPosition = getDropdownPosition();
+
+  return (
+    <div
+      className="relative"
+      ref={dropdownRef}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <div className="relative">
+        <Button
+          variant="elevated"
+          className={cn(
+            "h-11 px-4 bg-transparent border-transparent rounded-full text-black",
+            "hover:border-primary hover:bg-white",
+            isActive && !isNavigationHovered && "bg-white border-primary"
+          )}
+        >
+          {category.name}
+        </Button>
+
+        {category.subcategories && category.subcategories.length > 0 && (
+          <div
+            className={cn(
+              "opacity-0 absolute -bottom-3 w-0 h-0 border-l-[10px] border-r-[10px] border-l-transparent border-r-transparent border-b-black left-1/2 -translate-x-1/2 border-b-[10px]",
+              isOpen && "opacity-100"
+            )}
+          />
+        )}
+      </div>
+
+      <SubCategoryMenu
+        category={category}
+        isOpen={isOpen}
+        position={dropdownPosition}
+      />
+    </div>
+  );
+};

--- a/src/app/(app)/(home)/search-filters/index.tsx
+++ b/src/app/(app)/(home)/search-filters/index.tsx
@@ -1,0 +1,19 @@
+import { Categories } from "./categories";
+import { SearchInput } from "./search-input";
+
+interface Props {
+  data: any;
+}
+
+const SearchFilters = ({ data }: Props) => {
+  return (
+    <div>
+      <div className="px-4 lg:px-12 py-8 border-b flex flex-col gap-4 w-full">
+        <SearchInput />
+        <Categories data={data} />
+      </div>
+    </div>
+  );
+};
+
+export default SearchFilters;

--- a/src/app/(app)/(home)/search-filters/search-input.tsx
+++ b/src/app/(app)/(home)/search-filters/search-input.tsx
@@ -1,0 +1,24 @@
+import { SearchIcon } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+
+interface Props {
+  disabled?: boolean;
+}
+
+export const SearchInput = ({ disabled }: Props) => {
+  return (
+    <div className="flex items-center gap-2 w-full">
+      <div className="relative w-full">
+        <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-neutral-500" />
+        <Input
+          className="pl-8"
+          placeholder="Search products"
+          disabled={disabled}
+        />
+      </div>
+      {/* TODO: Add categories view all button */}
+      {/* TODO: Add library button */}
+    </div>
+  );
+};

--- a/src/app/(app)/(home)/search-filters/subcategory-menu.tsx
+++ b/src/app/(app)/(home)/search-filters/subcategory-menu.tsx
@@ -1,0 +1,49 @@
+import { Category } from "@/payload-types";
+import Link from "next/link";
+
+interface Props {
+  category: Category; // TODO: Change this
+  isOpen: boolean;
+  position: { top: number; left: number };
+}
+
+export const SubCategoryMenu = ({ category, isOpen, position }: Props) => {
+  if (
+    !isOpen ||
+    !category.subcategories ||
+    category.subcategories.length === 0
+  ) {
+    return null;
+  }
+
+  const backgroundColor = category.color || "#F5F5F5";
+
+  return (
+    <div
+      className="fixed z-100"
+      style={{
+        top: position.top,
+        left: position.left,
+      }}
+    >
+      {/* Invisible bridge to maintain hover */}
+      <div className="h-3 w-60" />
+      <div
+        style={{ backgroundColor }}
+        className="w-60 text-black rounded-md overflow-hidden border shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] -translate-x-[2px] -translate-y-[2px]"
+      >
+        <div>
+          {category.subcategories?.map((subcategory: Category) => (
+            <Link
+              key={subcategory.slug}
+              href="/"
+              className="w-full text-left p-4 hover:bg-black hover:text-white flex justify-between items-center underline font-medium"
+            >
+              {subcategory.name}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/app/(app)/(home)/search-filters/use-dropdown-position.ts
+++ b/src/app/(app)/(home)/search-filters/use-dropdown-position.ts
@@ -1,0 +1,38 @@
+import { RefObject } from "react";
+
+const LEFT_PADDING = 16;
+
+export const useDropdownPosition = (
+  ref: RefObject<HTMLDivElement | null> | RefObject<HTMLDivElement>
+) => {
+  const getDropdownPosition = () => {
+    if (!ref.current) return { top: 0, left: 0 };
+
+    const rect = ref.current.getBoundingClientRect();
+    const dropdownWidth = 240; // Width of dropdown (w-60 = 15rem = 240px)
+
+    // Calculate the initial position
+    let left = rect.left + window.scrollX;
+    const top = rect.bottom + window.scrollY;
+
+    // Check if dropdown would go off the right edge of the viewport
+    if (left + dropdownWidth > window.innerWidth) {
+      // Align to right edge of button instead
+      left = rect.right + window.scrollX - dropdownWidth;
+
+      // If still off-screen, align to the right edge of viewport
+      if (left < 0) {
+        left = window.innerWidth - dropdownWidth - LEFT_PADDING;
+      }
+    }
+
+    // Ensure dropdown doesn't go off left edge
+    if (left < 0) {
+      left = LEFT_PADDING;
+    }
+
+    return { top, left };
+  };
+
+  return { getDropdownPosition };
+};

--- a/src/collections/Categories.ts
+++ b/src/collections/Categories.ts
@@ -8,5 +8,29 @@ export const Categories: CollectionConfig = {
       type: "text",
       required: true,
     },
+    {
+      name: "slug",
+      type: "text",
+      required: true,
+      unique: true,
+      index: true,
+    },
+    {
+      name: "color",
+      type: "text",
+    },
+    {
+      name: "parent",
+      type: "relationship",
+      relationTo: "categories",
+      hasMany: false,
+    },
+    {
+      name: "subcategories",
+      type: "join",
+      collection: "categories",
+      on: "parent",
+      hasMany: true,
+    },
   ],
 };

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -74,7 +74,11 @@ export interface Config {
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
-  collectionsJoins: {};
+  collectionsJoins: {
+    categories: {
+      subcategories: 'categories';
+    };
+  };
   collectionsSelect: {
     users: UsersSelect<false> | UsersSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
@@ -158,6 +162,14 @@ export interface Media {
 export interface Category {
   id: string;
   name: string;
+  slug: string;
+  color?: string | null;
+  parent?: (string | null) | Category;
+  subcategories?: {
+    docs?: (string | Category)[];
+    hasNextPage?: boolean;
+    totalDocs?: number;
+  };
   updatedAt: string;
   createdAt: string;
 }
@@ -261,6 +273,10 @@ export interface MediaSelect<T extends boolean = true> {
  */
 export interface CategoriesSelect<T extends boolean = true> {
   name?: T;
+  slug?: T;
+  color?: T;
+  parent?: T;
+  subcategories?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
## 05 Search Filter

### 화면
![Image](https://github.com/user-attachments/assets/d48bbaaa-6e67-4afd-9f9c-486d448905c9)
![Image](https://github.com/user-attachments/assets/a520b633-fe5e-45e7-907a-b168e4c09e94)

### 작업 내역
- [x] Dropdown Menu 의 화살표 위치를 고정하기위한 `useDropdownPosition`훅을 추가
- [x] Dropdown Menu 의 화살표로 인한 빈 공간에 마우스 위치 시 드롭다운이 닫히지 않도록 빈공간 채우는 디자인요소 추가
- [x] 검색 바 UI 추가
- [x] 카테고리 및 서브 카테고리 추가
- [x] 카테고리 테이블에 `slug`, `color`, `parent`, `subcategories` 컬럼 추가
- [x] DB에서 카테고리 불러올 때 서브 카테고리는 별도로 구분되도록 코드 수정